### PR TITLE
add cancel scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 beef.txt
 sui.log.*
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 beef.txt
-sui.log.*
 build/
+sui.log.*

--- a/sui/.gitignore
+++ b/sui/.gitignore
@@ -1,3 +1,4 @@
 .coverage_map.mvcov
 .trace
 build/
+.env

--- a/sui/.gitignore
+++ b/sui/.gitignore
@@ -1,4 +1,4 @@
 .coverage_map.mvcov
+.env
 .trace
 build/
-.env

--- a/sui/Move.toml
+++ b/sui/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "GotBeef"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["juzybits <https://twitter.com/juzybits>"]
 license = "Apache-2.0"
 published-at = "0x8221cc562f8c58c922c6a40ecbc7e2f16b0159fb683470c22e96d21a0dc52beb"

--- a/sui/sources/bet.tests.move
+++ b/sui/sources/bet.tests.move
@@ -24,6 +24,15 @@ module gotbeef::bet_tests
     const JUDGES: vector<address> = vector[@0xB1, @0xB2];
     const SOMEONE: address = @0xC0B1E;
 
+    // Bet.phase possible values
+    // Using bet::PHASE_FUND in not possible
+    // Constants are internal to their module, and cannot can be accessed outside of their module.
+    const PHASE_FUND: u8 = 0;       
+    const PHASE_VOTE: u8 = 1;       
+    const PHASE_SETTLED: u8 = 2;    
+    const PHASE_CANCELED: u8 = 3;   
+    const PHASE_STALEMATE: u8 = 4;  
+
     /* Accessor tests */
 
     #[test]
@@ -184,7 +193,7 @@ module gotbeef::bet_tests
             // nobody has funded the bet yet
             assert!( vec_map::is_empty(funds), 0 );
             // the bet phase is set to PHASE_FUND
-            assert!( bet::phase(bet) == 0, 0 );
+            assert!( bet::phase(bet) == PHASE_FUND, 0 );
             ts::return_shared(bet_val);
         };
 
@@ -203,7 +212,7 @@ module gotbeef::bet_tests
             // and it's who you'd expect
             assert!( vec_map::contains(funds, &PLAYER_1), 0 );
             // the bet remains in the funding phase
-            assert!( bet::phase(bet) == 0, 0 );
+            assert!( bet::phase(bet) == PHASE_FUND, 0 );
             ts::return_shared(bet_val);
 
             // Player 1 got their change
@@ -226,7 +235,7 @@ module gotbeef::bet_tests
             // both players have funded the bet
             assert!( vec_map::contains(funds, &PLAYER_2), 0 );
             // the bet is now in the voting phase
-            assert!( bet::phase(bet) == 1, 0 );
+            assert!( bet::phase(bet) == PHASE_VOTE, 0 );
             ts::return_shared(bet_val);
 
             // Player 2 didn't get any change
@@ -376,7 +385,7 @@ module gotbeef::bet_tests
     /* cancel() tests */
 
     #[test]
-    fun cancel_success()
+    fun test_cancel_no_funds_success()
     {
         let scen_val = ts::begin(CREATOR);
         let scen = &mut scen_val; {
@@ -386,27 +395,28 @@ module gotbeef::bet_tests
             let bet_val = ts::take_shared<Bet<SUI>>(scen);
             let bet = &mut bet_val;
             bet::cancel( bet, ts::ctx(scen) );
-            assert!( bet::phase(bet) == 3, 0 );
+            assert!( bet::phase(bet) == PHASE_CANCELED, 0 );
             ts::return_shared(bet_val);
         };
         ts::end(scen_val);
     }
 
-    #[test, expected_failure(abort_code = gotbeef::bet::E_BET_HAS_FUNDS)]
-    /// Try to cancel a bet with funds
-    fun test_cancel_e_bet_has_funds()
+    #[test]
+    /// Any player or judge can cancel a bet if a player chickens out during funding
+    fun test_cancel_has_funds_success()
     {
         let scen_val = ts::begin(CREATOR);
         let scen = &mut scen_val; {
             create_bet(scen);
         };
         ts::next_tx(scen, PLAYER_1); { fund_bet(scen, BET_SIZE); };
-        ts::next_tx(scen, PLAYER_2); {
+        ts::next_tx(scen, PLAYER_1); {
             let bet_val = ts::take_shared<Bet<SUI>>(scen);
             let bet = &mut bet_val;
             bet::cancel( bet, ts::ctx(scen) );
             ts::return_shared(bet_val);
         };
+        // TODO check if PLAYER_1 received the funds
         ts::end(scen_val);
     }
 
@@ -427,9 +437,9 @@ module gotbeef::bet_tests
         ts::end(scen_val);
     }
 
-    #[test, expected_failure(abort_code = gotbeef::bet::E_NOT_IN_FUNDING_PHASE)]
+    #[test, expected_failure(abort_code = gotbeef::bet::E_BET_ALREADY_SETTLED)]
     /// Try to cancel a settled bet
-    fun test_cancel_e_not_in_funding_phase()
+    fun test_cancel_e_bet_already_settled()
     {
         let scen_val = ts::begin(CREATOR);
         let scen = &mut scen_val; {
@@ -445,10 +455,69 @@ module gotbeef::bet_tests
         ts::next_tx(scen, PLAYER_1); {
             let bet_val = ts::take_shared<Bet<SUI>>(scen);
             let bet = &mut bet_val;
-            assert!( bet::phase(bet) == 2, 0 ); // PHASE_SETTLED
+            assert!( bet::phase(bet) == PHASE_SETTLED, 0 );
             bet::cancel( bet, ts::ctx(scen) );
             ts::return_shared(bet_val);
         };
+        ts::end(scen_val);
+    }
+
+    #[test, expected_failure(abort_code = gotbeef::bet::E_CANCEL_REQUEST_ALREADY_MADE)]
+    /// Try to cancel a bet in the voting phase twice
+    fun test_cancel_e_cancel_request_already_made()
+    {
+        let scen_val = ts::begin(CREATOR);
+        let scen = &mut scen_val; {
+            create_bet(scen);
+        };
+
+        ts::next_tx(scen, PLAYER_1); { fund_bet(scen, BET_SIZE); };
+        ts::next_tx(scen, PLAYER_2); { fund_bet(scen, BET_SIZE); };
+
+        // judges are not showing up to vote, 
+        // PLAYER_1 tries to cancel the bet twice
+
+        ts::next_tx(scen, PLAYER_1); {
+            let bet_val = ts::take_shared<Bet<SUI>>(scen);
+            let bet = &mut bet_val;
+            assert!( bet::phase(bet) == PHASE_VOTE, 0 );
+            bet::cancel( bet, ts::ctx(scen) );
+            bet::cancel( bet, ts::ctx(scen) );
+            ts::return_shared(bet_val);
+        };
+        ts::end(scen_val);
+    }
+
+    #[test]
+    /// Try to cancel a bet in the voting phase
+    fun test_cancel_during_voting_success()
+    {
+        let scen_val = ts::begin(CREATOR);
+        let scen = &mut scen_val; {
+            create_bet(scen);
+        };
+
+        ts::next_tx(scen, PLAYER_1); { fund_bet(scen, BET_SIZE); };
+        ts::next_tx(scen, PLAYER_2); { fund_bet(scen, BET_SIZE); };
+
+        // judges are not showing up to vote
+
+        ts::next_tx(scen, PLAYER_1); {
+            let bet_val = ts::take_shared<Bet<SUI>>(scen);
+            let bet = &mut bet_val;
+            assert!( bet::phase(bet) == PHASE_VOTE, 0 );
+            bet::cancel( bet, ts::ctx(scen) );
+            ts::return_shared(bet_val);
+        };
+        ts::next_tx(scen, PLAYER_2); {
+            let bet_val = ts::take_shared<Bet<SUI>>(scen);
+            let bet = &mut bet_val;
+            assert!( bet::phase(bet) == PHASE_VOTE, 0 );
+            bet::cancel( bet, ts::ctx(scen) );
+            assert!( bet::phase(bet) == PHASE_CANCELED, 0 );
+            ts::return_shared(bet_val);
+        };
+
         ts::end(scen_val);
     }
 
@@ -511,7 +580,7 @@ module gotbeef::bet_tests
             /* judges */  vector[@0xB1],
             /* votes */   vector[@0xA1],
             /* quorum */  1,
-            /* expect_phase */ 2, // PHASE_SETTLED
+            /* expect_phase */ PHASE_SETTLED, 
             /* expect_winner */ option::some(@0xA1),
         );
 
@@ -521,7 +590,7 @@ module gotbeef::bet_tests
             /* judges */  vector[@0xB1, @0xB2],
             /* votes */   vector[@0xA1, @0xA2],
             /* quorum */  2,
-            /* expect_phase */ 4, // PHASE_STALEMATE
+            /* expect_phase */ PHASE_STALEMATE,
             /* expect_winner */ option::none<address>(),
         );
         test_expectations(
@@ -529,7 +598,7 @@ module gotbeef::bet_tests
             /* judges */  vector[@0xB1, @0xB2],
             /* votes */   vector[@0xA1, @0xA1],
             /* quorum */  2,
-            /* expect_phase */ 2, // PHASE_SETTLED
+            /* expect_phase */ PHASE_SETTLED,
             /* expect_winner */ option::some(@0xA1),
         );
 
@@ -539,7 +608,7 @@ module gotbeef::bet_tests
             /* judges */  vector[@0xB1, @0xB2, @0xB3, @0xB4, @0xB5],
             /* votes */   vector[@0xA1, @0xA2, @0xA3, @0xA4],
             /* quorum */  3,
-            /* expect_phase */ 4, // PHASE_STALEMATE
+            /* expect_phase */ PHASE_STALEMATE,
             /* expect_winner */ option::none<address>(),
         );
         test_expectations(
@@ -547,7 +616,7 @@ module gotbeef::bet_tests
             /* judges */  vector[@0xB1, @0xB2, @0xB3, @0xB4, @0xB5],
             /* votes */   vector[@0xA1, @0xA2, @0xA3, @0xA3, @0xA4],
             /* quorum */  3,
-            /* expect_phase */ 4, // PHASE_STALEMATE
+            /* expect_phase */ PHASE_STALEMATE,
             /* expect_winner */ option::none<address>(),
         );
         test_expectations(
@@ -555,7 +624,7 @@ module gotbeef::bet_tests
             /* judges */  vector[@0xB1, @0xB2, @0xB3, @0xB4, @0xB5],
             /* votes */   vector[@0xA1, @0xA2, @0xA3, @0xA3],
             /* quorum */  3,
-            /* expect_phase */ 1, // PHASE_VOTE
+            /* expect_phase */ PHASE_VOTE,
             /* expect_winner */ option::none<address>(),
         );
 
@@ -565,7 +634,7 @@ module gotbeef::bet_tests
             /* judges */  vector[@0xB1, @0xB2, @0xB3, @0xB4, @0xB5, @0xB6, @0xB7],
             /* votes */   vector[@0xA1, @0xA1, @0xA1, @0xA2, @0xA2, @0xA2],
             /* quorum */  5,
-            /* expect_phase */ 4, // PHASE_STALEMATE
+            /* expect_phase */ PHASE_STALEMATE,
             /* expect_winner */ option::none<address>(),
         );
 
@@ -575,7 +644,7 @@ module gotbeef::bet_tests
             /* judges */  vector[@0xB1, @0xB2, @0xB3, @0xB4, @0xB5, @0xB6, @0xB7],
             /* votes */   vector[@0xA1, @0xA1, @0xA1, @0xA2, @0xA2],
             /* quorum */  5,
-            /* expect_phase */ 1, // PHASE_VOTE
+            /* expect_phase */ PHASE_VOTE,
             /* expect_winner */ option::none<address>(),
         );
     }


### PR DESCRIPTION
The additional code provides the following new cancel scenarios which prevent player fund lock-up:

*   a player or judge can cancel a bet during the funding phase when one of the players chickens out
*   players can unanimously decide to cancel a bet during the voting phase (e.g. judges don't show up)

Some of the phase numbers in bet.tests.move are replaced by the actual phase name.  
New cancel unit tests were added.

'sui move test' runs successfully.